### PR TITLE
Syntax error in configuration file and deployment files

### DIFF
--- a/internal/controller/templates_telnet.go
+++ b/internal/controller/templates_telnet.go
@@ -91,18 +91,18 @@ security = {
   drb_ciphering = "yes";
   drb_integrity = "no";
 };
-     log_config :
-     {
-       global_log_level                      ="info";
-       hw_log_level                          ="info";
-       phy_log_level                         ="info";
-       mac_log_level                         ="info";
-       rlc_log_level                         ="debug";
-       pdcp_log_level                        ="info";
-       rrc_log_level                         ="info";
-       f1ap_log_level                         ="info";
-       ngap_log_level                         ="debug";
-    };
+log_config :
+{
+global_log_level                      ="info";
+hw_log_level                          ="info";
+phy_log_level                         ="info";
+mac_log_level                         ="info";
+rlc_log_level                         ="debug";
+pdcp_log_level                        ="info";
+rrc_log_level                         ="info";
+f1ap_log_level                         ="info";
+ngap_log_level                         ="debug";
+};
 
 `
 
@@ -229,7 +229,7 @@ gNBs =
         dl_offstToCarrier                                              = 0;
 # subcarrierSpacing
 # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-        dl_subcarrierSpacing                                           = {{ .DL_SCS }};;
+        dl_subcarrierSpacing                                           = {{ .DL_SCS }};
         dl_carrierBandwidth                                            = {{ .DL_CARRIER_BW }};
      #initialDownlinkBWP
       #genericParameters
@@ -249,7 +249,7 @@ gNBs =
       ul_offstToCarrier                                             = 0;
 # subcarrierSpacing
 # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      ul_subcarrierSpacing                                          = {{ .UL_SCS }};;
+      ul_subcarrierSpacing                                          = {{ .UL_SCS }};
       ul_carrierBandwidth                                           = {{ .UL_CARRIER_BW }};
       pMax                                                          = 20;
      #initialUplinkBWP

--- a/test-infra/oai-ue/20Mhz/uedeployment.yaml
+++ b/test-infra/oai-ue/20Mhz/uedeployment.yaml
@@ -28,11 +28,11 @@ spec:
           privileged: true
         env:
         - name: USE_ADDITIONAL_OPTIONS
-        # oai-gnb-du.oai-ran-du
+        # oai-du.oai-ran-du
           value: "--sa --rfsim --log_config.global_log_options level,nocolor,time -r 51 --numerology 1 -C 3609120000 --ssb 234 --uicc0.imsi 001010000000100"
         command: ["/bin/bash", "-c"]
         args:
-        - RFSIM_IP_ADDRESS=$(getent hosts oai-gnb-du.oai-ran-du | awk '{print $1}');
+        - RFSIM_IP_ADDRESS=$(getent hosts oai-du.oai-ran-du | awk '{print $1}');
           exec /opt/oai-nr-ue/bin/nr-uesoftmodem -O /opt/oai-nr-ue/etc/nr-ue.conf $USE_ADDITIONAL_OPTIONS --rfsimulator.serveraddr $RFSIM_IP_ADDRESS;
         volumeMounts:
         - mountPath: /opt/oai-nr-ue/etc/nr-ue.conf

--- a/test-infra/oai-ue/40Mhz/uedeployment.yaml
+++ b/test-infra/oai-ue/40Mhz/uedeployment.yaml
@@ -28,11 +28,11 @@ spec:
           privileged: true
         env:
         - name: USE_ADDITIONAL_OPTIONS
-        # oai-gnb-du.oai-ran-du
+        # oai-du.oai-ran-du
           value: "-r 106 --numerology 1 -C 3619200000 --ssb 516 -E --log_config.global_log_options level,nocolor,time --uicc0.imsi 001010000000100"
         command: ["/bin/bash", "-c"]
         args:
-        - RFSIM_IP_ADDRESS=$(getent hosts oai-gnb-du.oai-ran-du | awk '{print $1}');
+        - RFSIM_IP_ADDRESS=$(getent hosts oai-du.oai-ran-du | awk '{print $1}');
           exec /opt/oai-nr-ue/bin/nr-uesoftmodem -O /opt/oai-nr-ue/etc/nr-ue.conf $USE_ADDITIONAL_OPTIONS --rfsimulator.serveraddr $RFSIM_IP_ADDRESS;
         volumeMounts:
         - mountPath: /opt/oai-nr-ue/etc/nr-ue.conf


### PR DESCRIPTION
- Correct syntax error in the oai-du configuration file
- Update the service name of oai-du in nr-ue deployment file